### PR TITLE
Compatible with Windows Path & mecabrc requirements

### DIFF
--- a/mozcpy/mozcpy.py
+++ b/mozcpy/mozcpy.py
@@ -5,7 +5,7 @@ import MeCab
 
 DICT_DIR = os.path.join(os.path.dirname(__file__), 'dic')
 MECAB_ARGS = '-d %s' % DICT_DIR
-MECAB_ARGS += "-r /dev/null" if os.name == "posix" else "-r nul"
+MECAB_ARGS += ' -r /dev/null' if os.name == "posix" else ' -r nul'
 if os.sep == '\\':
     MECAB_ARGS = MECAB_ARGS.replace('\\', '\\\\')
 

--- a/mozcpy/mozcpy.py
+++ b/mozcpy/mozcpy.py
@@ -5,6 +5,9 @@ import MeCab
 
 DICT_DIR = os.path.join(os.path.dirname(__file__), 'dic')
 MECAB_ARGS = '-d %s' % DICT_DIR
+MECAB_ARGS += "-r /dev/null" if os.name == "posix" else "-r nul"
+if os.sep == '\\':
+    MECAB_ARGS = MECAB_ARGS.replace('\\', '\\\\')
 
 
 class Converter(object):


### PR DESCRIPTION
- Convert os.sep when using windows and use \ as path seperator, resolve #4 
- When use pip to install MeCab, import mecab may throw a misfound c:/mecab/mecabrc exception, resolve this issue